### PR TITLE
Make Image title non-editable for images that have already been saved [closes #94]

### DIFF
--- a/app/views/images/_form.html.haml
+++ b/app/views/images/_form.html.haml
@@ -9,7 +9,7 @@
       = f.input :canonical_id, as: :hidden
     = f.input :path
     = f.association :group, prompt: "Pick a group"
-    = f.input :title
+    = f.input :title, readonly: @image.persisted?
     = f.input :priority
     = f.input :tag_list, as: :tags, label: "Tags", input_html: {class: 'autocomplete'}, collection: ActsAsTaggableOn::Tag.most_used(30), hint: "Use a comma to separate new tags"
 


### PR DESCRIPTION
…database to prevent sync confusion; closes #94