### PR TITLE
feat: add ordinality column to resources and representations

### DIFF
--- a/app/helpers/resources_helper.rb
+++ b/app/helpers/resources_helper.rb
@@ -52,6 +52,7 @@ module ResourcesHelper
     end
 
     tags.push(tag_for('Urgent', type: :error)) if resource.priority_flag?
+    tags.push(resource.ordinality)
 
     (
       content_tag(title_tag, class: 'sr-only', id: "tag-list-#{id}") { "Properties for resource ##{resource.id}" } +

--- a/app/models/representation.rb
+++ b/app/models/representation.rb
@@ -16,6 +16,7 @@
 #  updated_at   :datetime         not null
 #  notes        :text
 #  endpoint_id  :bigint(8)        not null
+#  ordinality   :integer
 #
 # Indexes
 #

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -15,6 +15,7 @@
 #  representations_count :integer          default(0), not null
 #  priority_flag         :boolean          default(FALSE), not null
 #  host_uris             :string           default([]), not null, is an Array
+#  ordinality            :integer
 #
 # Indexes
 #

--- a/app/views/representations/_audits.slim
+++ b/app/views/representations/_audits.slim
@@ -10,6 +10,7 @@ table
       th Content Type
       th Language
       th Status
+      th Order
       th Metum
       th Endpoint
       th License
@@ -17,7 +18,7 @@ table
       th Notes
 
   tbody
-    - audits.each do |a, text: '', author_id: nil, content_type: nil, language: nil, status: nil, metum_id: nil, endpoint_id: nil, license_id: nil, content_uri: nil, notes: nil, **other|
+    - audits.each do |a, text: '', author_id: nil, content_type: nil, language: nil, status: nil, ordinality: nil, metum_id: nil, endpoint_id: nil, license_id: nil, content_uri: nil, notes: nil, **other|
       tr
         td= a.user
         td= a.action
@@ -27,6 +28,7 @@ table
         td= content_type
         td= language
         td= status
+        td= ordinality
         td= Metum.find_by(id: metum_id)&.title
         td= Endpoint.find_by(id: endpoint_id)&.name
         td= License.find_by(id: license_id)&.name

--- a/app/views/representations/_form.html.slim
+++ b/app/views/representations/_form.html.slim
@@ -12,6 +12,7 @@
       = f.input :text, as: :text, hint: 'It can be helpful to include a transcription of a non-text representation, when available'
       = f.input :status, collection: Coyote::Representation.status_collection if representation.persisted? && organization_user.admin?
       = f.input :notes, as: :text, hint: 'Useful for communicating internally with other Coyote members about this representation'
+      = f.input :ordinality, label: 'Ordinality', input_html: { min: 0, max: 100 }
       = f.association :metum, collection: available_meta
       = f.association :endpoint, collection: endpoint_collection, include_blank: false
       = f.input :language, as: :select, collection: language_list, include_blank: false

--- a/app/views/representations/show.html.slim
+++ b/app/views/representations/show.html.slim
@@ -26,6 +26,9 @@
           th Status
           td= representation.status.to_s.titleize
         tr
+          th Order
+          td= representation.ordinality
+        tr
           th Metum
           td= link_to(representation.metum_title, [current_organization, representation.metum])
         tr

--- a/app/views/resources/_form.html.slim
+++ b/app/views/resources/_form.html.slim
@@ -3,6 +3,7 @@
 
   = f.input :title, label: 'Caption'
   = f.input :priority_flag, as: :select, collection: [['High', true], ['Low', false]], include_blank: false, label: 'Priority' if organization_user.admin?
+  = f.input :ordinality, label: 'Order', input_html: { min: 0, max: 100 }
   = f.input :resource_type, label: 'Type', prompt: 'Pick a Dublin Core resource type', collection: Coyote::Resource.type_names, label_method: -> (t) { t.to_s.titleize }
   = f.input :canonical_id, required: true, label: "Canonical ID", hint: 'This should be a label used by the organization to uniquely identify this resource'
   = f.input :identifier, hint: 'This should be a unique string that does not change - used to identify the resource within Coyote. If blank, we will attempt to set one for you based on the title field.'

--- a/app/views/resources/_representations.html.slim
+++ b/app/views/resources/_representations.html.slim
@@ -1,6 +1,7 @@
 table
   thead
     th Status
+    th Order
     th Metum
     th Locale
     th Text
@@ -10,6 +11,7 @@ table
     - representations.each do |representation|
       tr
         td= representation_status_tag(representation)
+        td= representation.ordinality 
         td= metum_tag(representation.metum, hint: false)
         td: span.tag.tag--outline= representation.language
         td= to_html representation.text

--- a/db/migrate/20180825140356_add_ordinality_to_resources.rb
+++ b/db/migrate/20180825140356_add_ordinality_to_resources.rb
@@ -1,0 +1,5 @@
+class AddOrdinalityToResources < ActiveRecord::Migration[5.2]
+  def change
+    add_column :resources, :ordinality, :integer
+  end
+end

--- a/db/migrate/20180825140408_add_ordinality_to_representations.rb
+++ b/db/migrate/20180825140408_add_ordinality_to_representations.rb
@@ -1,0 +1,5 @@
+class AddOrdinalityToRepresentations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :representations, :ordinality, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -67,21 +67,6 @@ CREATE TYPE public.resource_type AS ENUM (
 );
 
 
---
--- Name: reset_sequence(text, text, text); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.reset_sequence(tablename text, columnname text, sequence_name text) RETURNS void
-    LANGUAGE plpgsql
-    AS $$
-      DECLARE
-      BEGIN
-      EXECUTE 'SELECT setval( ''' || sequence_name  || ''', ' || '(SELECT MAX(' || columnname || ') FROM ' || tablename || ')' || '+1)';
-      END;
-
-    $$;
-
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -466,7 +451,8 @@ CREATE TABLE public.representations (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     notes text,
-    endpoint_id bigint NOT NULL
+    endpoint_id bigint NOT NULL,
+    ordinality integer
 );
 
 
@@ -571,7 +557,8 @@ CREATE TABLE public.resources (
     updated_at timestamp without time zone NOT NULL,
     representations_count integer DEFAULT 0 NOT NULL,
     priority_flag boolean DEFAULT false NOT NULL,
-    host_uris character varying[] DEFAULT '{}'::character varying[] NOT NULL
+    host_uris character varying[] DEFAULT '{}'::character varying[] NOT NULL,
+    ordinality integer
 );
 
 
@@ -2077,6 +2064,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171121165017'),
 ('20180327144408'),
 ('20180614200303'),
-('20180710164016');
+('20180710164016'),
+('20180821193559'),
+('20180825140356'),
+('20180825140408');
 
 

--- a/spec/controllers/representations_controller_spec.rb
+++ b/spec/controllers/representations_controller_spec.rb
@@ -16,6 +16,7 @@
 #  updated_at   :datetime         not null
 #  notes        :text
 #  endpoint_id  :bigint(8)        not null
+#  ordinality   :integer
 #
 # Indexes
 #

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -15,6 +15,7 @@
 #  representations_count :integer          default(0), not null
 #  priority_flag         :boolean          default(FALSE), not null
 #  host_uris             :string           default([]), not null, is an Array
+#  ordinality            :integer
 #
 # Indexes
 #

--- a/spec/factories/representations.rb
+++ b/spec/factories/representations.rb
@@ -16,6 +16,7 @@
 #  updated_at   :datetime         not null
 #  notes        :text
 #  endpoint_id  :bigint(8)        not null
+#  ordinality   :integer
 #
 # Indexes
 #

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -15,6 +15,7 @@
 #  representations_count :integer          default(0), not null
 #  priority_flag         :boolean          default(FALSE), not null
 #  host_uris             :string           default([]), not null, is an Array
+#  ordinality            :integer
 #
 # Indexes
 #

--- a/spec/models/representation_spec.rb
+++ b/spec/models/representation_spec.rb
@@ -16,6 +16,7 @@
 #  updated_at   :datetime         not null
 #  notes        :text
 #  endpoint_id  :bigint(8)        not null
+#  ordinality   :integer
 #
 # Indexes
 #

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -15,6 +15,7 @@
 #  representations_count :integer          default(0), not null
 #  priority_flag         :boolean          default(FALSE), not null
 #  host_uris             :string           default([]), not null, is an Array
+#  ordinality            :integer
 #
 # Indexes
 #


### PR DESCRIPTION
Hey team! All I've done here (so far) is generate the ordinality columns on the resource and representation tables. Despite that it wasn't a bunch of work, I still wanted to create a pull request so that you could all keep a finger on the pulse and quickly point out if anything is off. I'll continue to add to this pull request as I complete the request for scoping by ordinality on the resources and representations. Thanks a million! 