### PR TITLE
Force 404 rather than crashing on false from current_user

### DIFF
--- a/lib/scavenger_hunt/app/controllers/scavenger_hunt/application_controller.rb
+++ b/lib/scavenger_hunt/app/controllers/scavenger_hunt/application_controller.rb
@@ -5,7 +5,7 @@ module ScavengerHunt
     helper_method def current_player
       return @current_player if defined? @current_player
       cookie = cookies[current_player_key]
-      @current_player = cookie.present? && Player.find_by(id: cookie)
+      @current_player = Player.find_by!(id: cookie)
     end
 
     helper_method def current_player?


### PR DESCRIPTION
The issue is users trying to view games that do not belong to them - this should trigger a 404, but the way `current_player` was written caused it to return `false` instead of throwing an `ActiveRecord::RecordNotFound` error. This is a fix for that issue.