### PR TITLE
Add a release phase for migrations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: bundle exec rake db:migrate
 web: bundle exec puma -C config/puma.rb

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/coyote-team/coyote",
   "keywords": ["rails"],
   "scripts": {
-    "postdeploy": "gem install bundler --no-ri --no-rdoc && bin/rake RAILS_ENV=production db:structure:load db:migrate coyote:db:start"
+    "postdeploy": "gem install bundler --no-ri --no-rdoc && bin/rake db:structure:load db:migrate db:seed scavenger_hunt:seed"
   },
   "image": "heroku/ruby",
   "env": {


### PR DESCRIPTION
This is cherry picked from the "streamlined deploy process" branch to ensure we _always_ run migrations when we push to Heroku.