### PR TITLE
fix: update prompt metum name so it reflects on the new answer view

### DIFF
--- a/lib/scavenger_hunt/app/models/scavenger_hunt/game.rb
+++ b/lib/scavenger_hunt/app/models/scavenger_hunt/game.rb
@@ -7,7 +7,7 @@ class ScavengerHunt::Game < ScavengerHunt::ApplicationRecord
   CLUE_METUM_NAME = "Scavenger Hunt: Clue".freeze
   CLUE_POSITION_METUM_NAME = "Scavenger Hunt: Clue Position".freeze
   HINT_METUM_NAME = "Scavenger Hunt: Hint".freeze
-  QUESTION_METUM_NAME = "Scavenger Hunt: Question".freeze
+  QUESTION_METUM_NAME = "Scavenger Hunt: Clue Prompt".freeze
 
   after_create :create_clues
 


### PR DESCRIPTION
I was testing Scavenger Hunt and noticed that the approved "Scavenger Hunt: Clue Prompt" metum wasn't being reflected on the new answer view. Instead, it was always defaulting to "I think it is...". 

So, I poked around and noticed that the metum's name needed to be updated still. This fixed it for me, but double check that it's the correct thing to do to make sure this always work right. Thanks! 