### PR TITLE
fix: rename prompt with question for consistency

### DIFF
--- a/db/migrate/20180912004124_rename_clue_prompt_to_question.rb
+++ b/db/migrate/20180912004124_rename_clue_prompt_to_question.rb
@@ -1,0 +1,5 @@
+class RenameCluePromptToQuestion < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :scavenger_hunt_clues, :prompt, :question
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -67,6 +67,21 @@ CREATE TYPE public.resource_type AS ENUM (
 );
 
 
+--
+-- Name: reset_sequence(text, text, text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.reset_sequence(tablename text, columnname text, sequence_name text) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+      DECLARE
+      BEGIN
+      EXECUTE 'SELECT setval( ''' || sequence_name  || ''', ' || '(SELECT MAX(' || columnname || ') FROM ' || tablename || ')' || '+1)';
+      END;
+
+    $$;
+
+
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -696,7 +711,7 @@ CREATE TABLE public.scavenger_hunt_clues (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     answer text,
-    prompt character varying DEFAULT 'I think it is...'::character varying
+    question character varying DEFAULT 'I think it is...'::character varying
 );
 
 
@@ -2179,12 +2194,12 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180327144408'),
 ('20180614200303'),
 ('20180710164016'),
-('20180821193559'),
 ('20180825140356'),
 ('20180825140408'),
 ('20180825193305'),
 ('20180829010109'),
 ('20180830121901'),
-('20180904221446');
+('20180904221446'),
+('20180912004124');
 
 

--- a/lib/scavenger_hunt/app/models/scavenger_hunt/clue.rb
+++ b/lib/scavenger_hunt/app/models/scavenger_hunt/clue.rb
@@ -44,7 +44,7 @@ class ScavengerHunt::Clue < ScavengerHunt::ApplicationRecord
 
   def set_question
     question_representation = resource.representations.with_metum_named(ScavengerHunt::Game::QUESTION_METUM_NAME).approved.first
-    self.prompt = question_representation.text if question_representation.present?
+    self.question = question_representation.text if question_representation.present?
     true
   end
 end

--- a/lib/scavenger_hunt/app/models/scavenger_hunt/clue.rb
+++ b/lib/scavenger_hunt/app/models/scavenger_hunt/clue.rb
@@ -1,7 +1,7 @@
 class ScavengerHunt::Clue < ScavengerHunt::ApplicationRecord
   after_create :create_hints
   before_save :set_position
-  before_save :set_prompt
+  before_save :set_question
 
   belongs_to :game
   belongs_to :representation
@@ -42,9 +42,9 @@ class ScavengerHunt::Clue < ScavengerHunt::ApplicationRecord
     end
   end
 
-  def set_prompt
-    prompt_representation = resource.representations.with_metum_named(ScavengerHunt::Game::QUESTION_METUM_NAME).approved.first
-    self.prompt = prompt_representation.text if prompt_representation.present?
+  def set_question
+    question_representation = resource.representations.with_metum_named(ScavengerHunt::Game::QUESTION_METUM_NAME).approved.first
+    self.prompt = question_representation.text if question_representation.present?
     true
   end
 end

--- a/lib/scavenger_hunt/app/views/scavenger_hunt/answers/new.html.slim
+++ b/lib/scavenger_hunt/app/views/scavenger_hunt/answers/new.html.slim
@@ -1,4 +1,4 @@
 - body_class :inverted
-h1= @clue.prompt
+h1= @clue.question
 
 = render "form"

--- a/spec/scavenger_hunt/models/game_spec.rb
+++ b/spec/scavenger_hunt/models/game_spec.rb
@@ -182,8 +182,8 @@ RSpec.describe ScavengerHunt::Game do
   end
 
   it "uses the question metum to set questions" do
-    expect(subject.clues.first.prompt).to eq(question_2.text)
-    expect(subject.clues.last.prompt).to eq(question_1.text)
+    expect(subject.clues.first.question).to eq(question_2.text)
+    expect(subject.clues.last.question).to eq(question_1.text)
   end
 
   it "generates hints on clues ordered by ordinality" do

--- a/spec/scavenger_hunt/models/game_spec.rb
+++ b/spec/scavenger_hunt/models/game_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ScavengerHunt::Game do
   let(:clue_metum) do
     create(:metum, organization: organization, title: ScavengerHunt::Game::CLUE_METUM_NAME)
   end
-  let(:clue_prompt_metum) do
+  let(:question_metum) do
     create(:metum, organization: organization, title: ScavengerHunt::Game::QUESTION_METUM_NAME)
   end
   let(:hint_metum) do
@@ -56,10 +56,10 @@ RSpec.describe ScavengerHunt::Game do
     })
   end
 
-  # ...and a custom answer prompt
-  let!(:prompt_1) do
+  # ...and a custom question
+  let!(:question_1) do
     create(:representation, {
-      metum: clue_prompt_metum,
+      metum: question_metum,
       resource: resource_1,
       status: "approved",
       text: "This is the first answer:"
@@ -100,10 +100,10 @@ RSpec.describe ScavengerHunt::Game do
     })
   end
 
-  # ...and an answer prompt
-  let!(:prompt_2) do
+  # ...and a question
+  let!(:question_2) do
     create(:representation, {
-      metum: clue_prompt_metum,
+      metum: question_metum,
       resource: resource_2,
       status: "approved",
       text: "Answer #2 is..."
@@ -181,9 +181,9 @@ RSpec.describe ScavengerHunt::Game do
     expect(subject.clues.last.answer).to eq(answer_1.text)
   end
 
-  it "uses the prompt metum to set clue prompts" do
-    expect(subject.clues.first.prompt).to eq(prompt_2.text)
-    expect(subject.clues.last.prompt).to eq(prompt_1.text)
+  it "uses the question metum to set questions" do
+    expect(subject.clues.first.prompt).to eq(question_2.text)
+    expect(subject.clues.last.prompt).to eq(question_1.text)
   end
 
   it "generates hints on clues ordered by ordinality" do


### PR DESCRIPTION
These updates are not critical to the functionality of Coyote, but I had work time and @sinabahram mentioned removing all mentions of `prompt`. I think it would be awesome to have them all say `question` so that any new developer that joins the team will experience consistency. 

All Rspec tests for `game_spec.rb` are passing with the code in this first commit. 

I've gone through and updated most of the references to the `Scavenger Hunt: Question` that say `prompt` to say `question` instead. There are a few that I have not updated yet because they involve the database and I'm not sure if we should do those or not. If we do, I want to check first to make sure I don't mess things up. 

