### PR TITLE
fix: render answer submit button in view - needs code review and styling

### DIFF
--- a/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_button.sass
+++ b/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_button.sass
@@ -2,10 +2,11 @@ button
   appearance: none
   background: transparent
   border-width: 0
-  bottom: 0
   display: inline-block
   font: inherit
   margin: 0
-  padding: 0 0 15px 0
   position: absolute
   text-decoration: underline
+
+button.button--inverted
+  color: $background

--- a/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
+++ b/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
@@ -1,6 +1,6 @@
 = form_for @answer, url: game_clue_answer_path(@game, @clue) do |form|
   label.sr-only for="answer" Enter object title
-  = text_field_tag :answer, "", placeholder: "Enter object title", :required => true
+  = text_field_tag :answer, "", placeholder: "Enter object title", required: true
   .toolbar
     = toolbar_item do
       = link_to game_clue_path(@game, @clue), class: "large" do

--- a/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
+++ b/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
@@ -1,13 +1,13 @@
 = form_for @answer, url: game_clue_answer_path(@game, @clue) do |form|
   label.sr-only for="answer" Enter object title
-  = text_field_tag :answer, "", placeholder: "Enter object title"
-
+  = text_field_tag :answer, "", placeholder: "Enter object title", :required => true
+  .toolbar
     = toolbar_item do
       = link_to game_clue_path(@game, @clue), class: "large" do
         | Return
         br
         | to clue
     = toolbar_item do
-      button.large type="submit" Submit
+      = submit_tag "Submit", class: "button large"
 
 = render 'scavenger_hunt/games/footer'

--- a/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
+++ b/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
@@ -8,6 +8,6 @@
         br
         | to clue
     = toolbar_item do
-      = submit_tag "Submit", class: "button large"
+      button.button--inverted.large type="submit" Submit
 
 = render 'scavenger_hunt/games/footer'


### PR DESCRIPTION
Hi @flipsasser!

This took me way longer than I'll ever admit. So, before I spend any more time styling it, I wanted to see what you thought about the code. The button code that was there originally wasn't rendering a button in the view. So I tried a few different things and thought this looked the cleanest. I also added server-side validation because I was getting a params error when I'd try to submit with nothing in the text field (obvs.) 

1) What is the best way to do the button code here? How can I make my code better fit what is there? 

2) When it comes to styling, I need to make it appear like the `link_to game_clue_path(@game, @clue), class: "large"` but I think because I'm using the submit_tag, it's making it more like a button (really wide). So, I'm wondering if you know the best way to get it to ignore those styles and respect the `toolbar_item` styling? 

Thanks! 