### PR TITLE
fix: update new answer input placeholder color and content, closes #215, closes #216

### DIFF
--- a/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_input.sass
+++ b/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_input.sass
@@ -9,3 +9,6 @@ input
   font-weight: 600
   padding: 11px 0 11px 11px
   width: 100%
+
+.input-inverted::placeholder
+  color: $background

--- a/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_input.sass
+++ b/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_input.sass
@@ -10,5 +10,10 @@ input
   padding: 11px 0 11px 11px
   width: 100%
 
+input:focus
+    box-shadow: 0 0 5px $tint
+    border: 0 solid $tint
+    outline: none
+
 .input-inverted::placeholder
   color: $background

--- a/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
+++ b/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
@@ -1,6 +1,6 @@
 = form_for @answer, url: game_clue_answer_path(@game, @clue) do |form|
   label.sr-only for="answer" Enter object title
-  = text_field_tag :answer, "", placeholder: "Enter object title"
+  = text_field_tag :answer, "", placeholder: "Enter answer", class: "input-inverted"
 
     = toolbar_item do
       = link_to game_clue_path(@game, @clue), class: "large" do


### PR DESCRIPTION
@flipsasser I used a global variable here to make the placeholder white. I put it in the `_input.sass`, but do you think it would be better in the css that's written in the `_location_styles.html.slim`? I can easily move it over there if you think that is better. I'm sure there are a bunch of ways to achieve this, so let me know if you think there is a better method. Thanks so much! 


**Update:** I just saw issue #216 which fits well on this feature branch. Anna wants the focus halo color to not be orange (there is probably a better name for it than focus halo...). I updated it to the blue global variable for $tint - that's a pretty standard focus color. BUT, just like any time I've touched styling so far in my VERY short dev career, I feel like I hacked it together. So, let me know if it's garbage and what I should do to make it better. :-P  