### PR TITLE
fix: change - to -- on inverted modifier

### DIFF
--- a/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_input.sass
+++ b/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_input.sass
@@ -15,5 +15,5 @@ input:focus
     border: 0 solid $tint
     outline: none
 
-.input-inverted::placeholder
+.input--inverted::placeholder
   color: $background

--- a/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
+++ b/lib/scavenger_hunt/app/views/scavenger_hunt/answers/_form.html.slim
@@ -1,6 +1,6 @@
 = form_for @answer, url: game_clue_answer_path(@game, @clue) do |form|
   label.sr-only for="answer" Enter object title
-  = text_field_tag :answer, "", placeholder: "Enter answer", class: "input-inverted"
+  = text_field_tag :answer, "", placeholder: "Enter answer", class: "input--inverted"
 
     = toolbar_item do
       = link_to game_clue_path(@game, @clue), class: "large" do


### PR DESCRIPTION
This is low priority. Just a one character update. 

In response to: _"This looks good. I'll say that you should double-check the modular CSS stuff I sent over - modifiers are typically separated by two hyphens instead of one, so an input .input that's inverted would be something like .input.input--inverted - that helps maintain the concept of "this is an input, but it also has a modifier applied to it" rather than what might read as "this is an input and also an input-inverted" - hopefully that makes sense"_

YES! OF COURSE! I had it as - in my head. Noted and updated! Thanks for all the excellent feedback @flipsasser! 