### PR TITLE
Add ability to edit organizations, closes #213

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 # Manges requests to view and manipulate Organization objects
 # @see Organization
 class OrganizationsController < ApplicationController
-  before_action :set_current_organization, only: %i[show edit] # helps avoid scenario where ActionView::Template::Error can swallow ActiveRecord::RecordNotFound, when a user is not a member of an org
+  before_action :set_current_organization, only: %i[show edit update] # helps avoid scenario where ActionView::Template::Error can swallow ActiveRecord::RecordNotFound, when a user is not a member of an org
   before_action :authorize_general_access, only: %i[new index create]
   before_action :authorize_unit_access,    only: %i[show edit update destroy]
 

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -20,7 +20,6 @@ class OrganizationPolicy < ApplicationPolicy
   # @return [true] if the user is an owner of the organization
   # @return [false] otherwise
   def update?
-    binding.pry
     organization_user.owner?
   end
 

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -20,6 +20,7 @@ class OrganizationPolicy < ApplicationPolicy
   # @return [true] if the user is an owner of the organization
   # @return [false] otherwise
   def update?
+    binding.pry
     organization_user.owner?
   end
 

--- a/app/views/organizations/index.html.slim
+++ b/app/views/organizations/index.html.slim
@@ -11,8 +11,8 @@ table
       tr
         td= link_to(org.title, organization_path(org))
         td.table-cell-actions
-          / - if current_user == organization.owner/creator? Need to insert policy here.
-          = link_to('Edit', edit_organization_path(org), class: 'button button--outline', title: "Edit #{org}")
+          - if OrganizationPolicy.new(Coyote::OrganizationUser.new(current_user, org), org).edit?
+            = link_to('Edit', edit_organization_path(org), class: 'button button--outline', title: "Edit #{org}")
 
 
 nav.toolbar.toolbar--footer

--- a/app/views/organizations/index.html.slim
+++ b/app/views/organizations/index.html.slim
@@ -1,8 +1,19 @@
-h1= title 'Your Organizations'
+table
+  caption
+    h1= title 'Your Organizations'
+  thread
+    tr
+      th Organization
+      th.table-cell-actions Actions
 
-= list do |org|
-  - current_user.organizations.each do |org|
-    = link_to_list_item(org.title, organization_path(org))
+  tbody
+    - organizations.each do |org|
+      tr
+        td= link_to(org.title, organization_path(org))
+        td.table-cell-actions
+          / - if current_user == organization.owner/creator? Need to insert policy here.
+          = link_to('Edit', edit_organization_path(org), class: 'button button--outline', title: "Edit #{org}")
+
 
 nav.toolbar.toolbar--footer
   h2.sr-only Actions

--- a/app/views/organizations/index.html.slim
+++ b/app/views/organizations/index.html.slim
@@ -1,7 +1,7 @@
 table
   caption
     h1= title 'Your Organizations'
-  thread
+  thead
     tr
       th Organization
       th.table-cell-actions Actions


### PR DESCRIPTION
**This PR allows the owner of an organization the ability to edit the organization by clicking the 'Edit' button on the organizations index view.** 

<hr>

I'm not super happy about the authorization line I added to the view, but followed Pundit's documentation to get it working. Ideally, I'd be able to call: 
```
- if policy(organization_user, org).edit? 
```
because you can call `policy` and pass through a user and a record then see if it is authorized to take an action. But, for some reason (that I could not figure out after an embarrassing amount of searching) the organization was not being passed through here and was resulting in Pundit returning a NilClass policy instead of OrganizationPolicy. So I had to use this line to instantiate a new instance and manually pass through the `current_user` and `org`: 
```
- if OrganizationPolicy.new(Coyote::OrganizationUser.new(current_user, org), org).edit?
```

Does anyone have thoughts on this? I'm happy to create an issue that will lead me to opening this back up and reinvestigating someday, but I think that it is working fine for now and I should move on to other issues since I'm pretty stumped. 

**Pundit Documentation:** https://github.com/varvet/pundit#policies