### PR TITLE
nix all uppercase in scavenger hunt, closes #224

### DIFF
--- a/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_helper.sass
+++ b/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_helper.sass
@@ -5,7 +5,6 @@ a.no-border
   border-bottom: none
   font-size: $font-size-h2
   font-weight: bold
-  text-transform: uppercase
 
 .end-game
   color: $text

--- a/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_typography.sass
+++ b/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_typography.sass
@@ -2,19 +2,16 @@ h1, .title
   font-size: $font-size-h1
   font-weight: 600
   margin: 0 0 $superview 0
-  text-transform: uppercase
 
 h2, .subtitle
   font-size: $font-size-h2
   font-weight: 600
   margin: 0 0 $superview 0
-  text-transform: uppercase
   padding-top: $gutter
 
 h3, .large
   font-size: $font-size-h3
   font-weight: 600
-  text-transform: uppercase
 
 p
   line-height: $line-height
@@ -33,12 +30,10 @@ p
 .default
   font-size: $font-size
   font-weight: 600
-  text-transform: uppercase
 
 .small
   font-size: $font-size-small
   font-weight: 600
-  text-transform: uppercase
 
 a
   line-height: $line-height-ratio


### PR DESCRIPTION
This was a quick easy change to comply with accessibility requirements. I simply removed all css `text-transform: uppercase` from the Scavenger Hunt. Shouldn't require any feedback. Although, @alavatelliMCA will want to go through and let me know if there are any words that do need uppercase letters that didn't get them when coded. Like, "scavenger hunt"? 