### PR TITLE
change input focus on color background to white, closes #216

### DIFF
--- a/lib/scavenger_hunt/app/views/layouts/scavenger_hunt/_location_styles.html.slim
+++ b/lib/scavenger_hunt/app/views/layouts/scavenger_hunt/_location_styles.html.slim
@@ -27,6 +27,12 @@ css:
     border-color: #{color};
   }
 
+  input:focus, textarea:focus, select:focus {
+    box-shadow: 0 0 5px white;
+    border: 3px solid white;
+    outline: none;
+  }
+
   body.inverted input {
     border-color: white;
   }


### PR DESCRIPTION
Per issue #216 we agreed that when the background is color, the input focus color should be white. That will ensure it is accessible with every organization's color choice (since the requirement for their choice is to be accessible with white). 