### PR TITLE
require the player have a name present before rendering player show view

### DIFF
--- a/lib/scavenger_hunt/app/controllers/scavenger_hunt/players_controller.rb
+++ b/lib/scavenger_hunt/app/controllers/scavenger_hunt/players_controller.rb
@@ -14,7 +14,7 @@ class ScavengerHunt::PlayersController < ScavengerHunt::ApplicationController
   end
 
   def show
-    redirect_to new_player_path unless current_player?
+    redirect_to new_player_path unless current_player? && current_player.name.present?
   end
 
   def update


### PR DESCRIPTION
Originally, this line: `redirect_to new_player_path unless current_player? && current_player.name.present?` was this: `redirect_to new_player_path unless current_player? && current_player.email.present?` I removed everything after `&&` because I thought, "oh, email isn't required and I shouldn't be hiding the show view from a player who has submitted all the required information". Then after testing Scavenger Hunt, I noticed I was never getting served the new player view realized, "duh, I'm never being `redirect_to` the `new_player_path` because the only code remaining was ensuring a current_player existed. Which it did. But I needed to have a current_player in existence AND that player must have a `name` present (which is the required field - whereas email is not). 