### PR TITLE
fix audits to display updated values

### DIFF
--- a/app/views/representations/_audits.slim
+++ b/app/views/representations/_audits.slim
@@ -18,7 +18,7 @@ table
       th Notes
 
   tbody
-    - audits.each do |a, text: '', author_id: nil, content_type: nil, language: nil, status: nil, ordinality: nil, metum_id: nil, endpoint_id: nil, license_id: nil, content_uri: nil, notes: nil, **other|
+    - audits.each do |a, text: '', author_id: nil, content_type: nil, language: nil, status: nil, ordinality: '', metum_id: nil, endpoint_id: nil, license_id: nil, content_uri: '', notes: '', **other|
       tr
         td= a.user
         td= a.action
@@ -26,10 +26,10 @@ table
         td= to_html(text.to_s)
         td= User.find_by(id: author_id)&.username
         td= content_type
-        td: span.tag.tag--outline= representation.language
-        td= representation_status_tag(representation)
+        td= language
+        td= status
         td= ordinality
-        td= metum_tag(representation.metum, hint: false)
+        td= Metum.find_by(id: metum_id)&.title
         td= Endpoint.find_by(id: endpoint_id)&.name
         td= License.find_by(id: license_id)&.name
         td= content_uri


### PR DESCRIPTION
Ok, so there is still work to be done on this branch before it can close out any issues, but I wanted to get what I did pushed so that it could improve what is currently there. 

A while back, I was fixing some style issues on the audit log (displaying the tag style for values on the audit table), but to be honest, didn't understand the Audited library - or even know what it was and how it displayed. Anyway, I know more now and see that the tag styles I was applying didn't work with Audited. So this is basically restoring functionality so that the audit log shows the previous value and the updated value. 

It also includes a fix for this comment of Anna's "some columns display [nil, ""] as opposed to being blank". 

To fix this, we needed to set the default value of all text field attributes to "" instead of nil, because what is happening is that Audited is reporting all updates in the audit log and when we set the default to nil, the user clicks save on their edit form and blank text fields are submitted. Therefore, Audited says: this field was updated from nil to "". On our audits table, we need to set the starting value of any text fields to "". That being said, when a new value is originally set, you will still see ["", "https://www.example.com/"] because it is showing that the value used to be: empty string. Now it is: whatever the updated value is. However, it won't capture a change from nil to "".