### PR TITLE
remove representations from queue on status change

### DIFF
--- a/app/controllers/representations_controller.rb
+++ b/app/controllers/representations_controller.rb
@@ -42,7 +42,10 @@ class RepresentationsController < ApplicationController
   def update
     if representation.update(representation_params)
       logger.info "Updated #{representation}"
-      redirect_to representation_path(representation), notice: 'The description has been updated'
+      respond_to do |format|
+        format.html { redirect_to representation_path(representation), notice: 'The description has been updated' }
+        format.js
+      end
     else
       logger.warn "Unable to update description due to '#{representation.error_sentence}'"
       render :edit

--- a/app/views/organizations/show.html.slim
+++ b/app/views/organizations/show.html.slim
@@ -75,7 +75,7 @@ header
 
   h3#ready_to_review Descriptions Ready to Review
   - if current_organization.ready_to_review_representations.any?
-    = list class: 'list--grid' do
+    = list class: 'list--grid', id: "ready_to_review_partial" do
       = render partial: 'representations/resource', collection: current_organization.ready_to_review_representations.first(50).group_by(&:resource), as: :resource_and_representations
   - else
     p There are currently no descriptions in the 'Ready to Review' state for this orgnization

--- a/app/views/representations/_resource.html.slim
+++ b/app/views/representations/_resource.html.slim
@@ -7,7 +7,7 @@ li.list-item
     span.sr-only Caption:
     = to_html resource.title
     - representations.each do |representation|
-      .timeline-item
+      .timeline-item class="representation-#{representation.id}"
         - if defined? form
           = check_box_tag  "representation_status_change[representation_ids][]", representation.id, nil, aria: { label: "Select representation #{representation.id} for bulk update"}
         = to_html representation.text
@@ -34,9 +34,9 @@ li.list-item
               li.list-item-actions-item
                 = link_to 'Delete', representation, title: "Delete this representation", class: "button button--outline",  method: :delete, data: { confirm: "Are you sure you want to delete #{representation}?"}, aria: { describedby: dom_id(representation) }
           - else
-            = simple_form_for representation, html: { class: 'form form--inline' }, wrapper: :inline do |f|
+            = simple_form_for representation, remote: true, html: { class: 'form form--inline' }, wrapper: :inline do |f|
               = f.input_field :status, as: :hidden, value: "approved"
               = f.submit "Approve", class: "button button--outline", aria: { label: "Approve representation ##{representation.id}" }
-            = simple_form_for representation, html: { class: 'form form--inline' }, wrapper: :inline do |f|
+            = simple_form_for representation, remote: true, html: { class: 'form form--inline' }, wrapper: :inline do |f|
               = f.input_field :status, as: :hidden, value: "not_approved"
               = f.submit "Reject", class: "button button--outline", aria: { label: "Approve representation ##{representation.id}" }

--- a/app/views/representations/update.js.erb
+++ b/app/views/representations/update.js.erb
@@ -1,0 +1,2 @@
+var element = document.getElementById("ready_to_review_partial")
+element.innerHTML = "<%= escape_javascript(render partial: 'representations/resource', collection: current_organization.ready_to_review_representations.first(50).group_by(&:resource), as: :resource_and_representations, class: 'list--grid'  ) %>";


### PR DESCRIPTION
@flipsasser I did some AJAX! But then I got stuck a little... 

So, I've successfully implemented AJAX to update the representation's status without reloading the page and have it removing the representation from the resource card. 

My problem is: The resource card doesn't resize when the representation is removed. And when there are no more representations, the resource needs to disappear. Probably something like `if representation.last remove paretNode` (only in an actual coding language - lol)

Do you have any thoughts on how I should accomplish that? I'm going to keep researching, but let me know if you have ideas! 


