### PR TITLE
fix select all feature on representations view, closes #202

### DIFF
--- a/app/views/representations/index.html.slim
+++ b/app/views/representations/index.html.slim
@@ -59,7 +59,7 @@
             span.sr-only Grid View
 
         - if record_filter.browser_pagination_link_params.any?
-          = toolbar_item class: 'non-mobile-only' do
+          = toolbar_item do
             = paginate record_filter.records
 
       - if params[:grid].present?


### PR DESCRIPTION
Ok, so the fix was to remove the `non-mobile-only` class from the toolbar-item. I cannot explain it, but that did the trick. So 2 questions: 

1. Any idea why that was messing it up? 

2. Can you think of a way we can still apply that class and not have it affect the functionality of the select all? 

@flipsasser 