### PR TITLE
create about page for scavenger hunt, closes #310

### DIFF
--- a/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_helper.sass
+++ b/lib/scavenger_hunt/app/assets/stylesheets/scavenger_hunt/components/_helper.sass
@@ -7,6 +7,13 @@ a.no-border
   font-weight: bold
   text-transform: uppercase
 
+.scavenger-hunt-about
+  border-bottom: none
+  float: right
+  font-size: $font-size-h2
+  font-weight: bold
+  text-transform: uppercase
+
 .end-game
   color: $text
   border-color: $text !important

--- a/lib/scavenger_hunt/app/controllers/scavenger_hunt/pages_controller.rb
+++ b/lib/scavenger_hunt/app/controllers/scavenger_hunt/pages_controller.rb
@@ -1,0 +1,5 @@
+class ScavengerHunt::PagesController < ScavengerHunt::ApplicationController
+  def show
+    render template: "scavenger_hunt/pages/about"
+  end
+end

--- a/lib/scavenger_hunt/app/views/layouts/scavenger_hunt/application.html.slim
+++ b/lib/scavenger_hunt/app/views/layouts/scavenger_hunt/application.html.slim
@@ -13,8 +13,11 @@ html(lang="en")
     nav#nav-main role="navigation"
       h2.sr-only#navigation Navigation
       ul aria-labelledby="navigation"
-        li
-          = link_to 'Coyote', root_path, class: "scavenger-hunt-logo"
+      .toolbar
+          li
+            = link_to 'Coyote', root_path, class: "scavenger-hunt-logo"
+          li
+            = link_to "?", page_path("about"), class: "scavenger-hunt-about"
       = yield :nav
     main#main
       = yield

--- a/lib/scavenger_hunt/app/views/scavenger_hunt/pages/about.html.slim
+++ b/lib/scavenger_hunt/app/views/scavenger_hunt/pages/about.html.slim
@@ -1,0 +1,35 @@
+p.default
+  | The Coyote Scavenger Hunt uses descriptions that were originally created to help visitors who are or blind or have low vision enjoy artworks and cultural objects. Its software was developed by the Museum of Contemporary Art Chicago and Prime Access Consulting to support the authoring, management, and publication of visual descriptions for web visitors.
+p.default
+  | The generous support of the John S. and James L. Knight Foundation and Lois and Steve Eisen and The Eisen Family Foundation has made it possible for us to share the open-source Coyote software with other institutions and to produce the description-based Coyote Scavenger Hunt. Learn more about Coyote at coyote.pics.
+
+h2 TEAM COYOTE
+h3 For the Museum of Contemporary Art Chicago:
+ul
+  li Susan Chun, Chief Content Officer
+  li Anna Chiaretta Lavatelli, Director of Digital Media
+  li Gabriel Melcher, Design Director
+  li Sheila Majumdar, Senior Editor
+  li Bridget Reilly O’Carroll, Associate Video Producer
+  li Alexander Shoup, Web Developer
+  li Dorothy Lin, Production Designer
+  li Leah Froats, Associate Editor
+  li Lorenzo Conte, Manager of Planning and Production
+  li Christina Stephens, Publishing Administrative Assistant
+  li Tobey Albright, former Senior Interactive Designer
+  li Shauna Skalitzky, former Web Content Manager and Editor
+  li Joe Iverson, former Manager of Planning and Production
+
+h3 For Prime Access Consulting:
+ul
+  li Sina Bahram, Principal
+  li Mike Subelsky, Software Architect
+  li Flip Sasser, Software Lead
+  li Stacie Taylor-Cima, Junior Developer
+
+h3 Thanks to our partner organizations for participating in Coyote Scavenger Hunt:
+ul
+  li Chicago Cultural Center
+  li Graham Foundation
+  li Shedd Aquarium
+  li Smart Museum of Art at the University of Chicago

--- a/lib/scavenger_hunt/config/routes.rb
+++ b/lib/scavenger_hunt/config/routes.rb
@@ -1,5 +1,6 @@
 ScavengerHunt::Engine.routes.draw do
   root to: 'home#index'
+
   resources :locations, only: %w(index show) do
     resource :game, only: :new
     resource :leaderboard, only: :show
@@ -10,6 +11,8 @@ ScavengerHunt::Engine.routes.draw do
       end
     end
   end
+
+  resources :pages, only: :show
 
   resources :games, only: :show do
     member do


### PR DESCRIPTION
Hi @flipsasser! This static page is working, but I have a few questions on how I can refactor the code. Since we're on a time crunch I didn't want to spend too much time on it and if I don't hear back from you within the next hour, I am going to go ahead and merge it (since it's not broken code or anything) and I'll create an issue about refactoring it. 

**First thing:** I tried to get the route and pages#show method to be dynamic. Meaning work with something like this in the route: ` get "/pages/:page" => "pages#show"
`and this in the show method: `render template: "pages/#{params[:page]}"` but I couldn't get it working in the engine, so I just made it explicit. Do you have thoughts on how/if I should do that? 

**Second thing:** I've got some sass that could be cleaned up, but can't seem to get the syntax. Again, I probably could if I spent more time learning, but I'm trying to hustle through today. Let me know how I can make all these styles inherit and I'll clean it up. If I don't hear back from you, I'll generate a ticket for me to go do this next week after this big launch: 

All these styles have border-bottom: none. Then the second two have 3 of the same. Then the third has one extra style that the second doesn't. So, I know this can cascade. Also, I am seeing now that I'm typing this that I never updated the "no-border" to be something link "discrete-link" or something "-link". 
```
a.no-border
  border-bottom: none

.scavenger-hunt-logo
  border-bottom: none
  font-size: $font-size-h2
  font-weight: bold
  text-transform: uppercase

.scavenger-hunt-about
  border-bottom: none
  float: right
  font-size: $font-size-h2
  font-weight: bold
  text-transform: uppercase
```