### PR TITLE
Include membership information within /profile API response

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -10,7 +10,7 @@ module Api
 
     api! "Return the authenticated user and their organization memberships"
     def show
-      render jsonapi: current_user, include: %i[organizations]
+      render jsonapi: current_user, include: %i[memberships organizations]
     end
   end
 end

--- a/app/serializers/serializable_membership.rb
+++ b/app/serializers/serializable_membership.rb
@@ -4,4 +4,9 @@ class SerializableMembership < JSONAPI::Serializable::Resource
   type "membership"
 
   attributes :active, :first_name, :last_name, :email, :role
+
+  attribute :organization_id do
+    # Map integer to string for response consistency
+    @object.organization_id.to_s
+  end
 end

--- a/app/serializers/serializable_user.rb
+++ b/app/serializers/serializable_user.rb
@@ -8,7 +8,15 @@ class SerializableUser < JSONAPI::Serializable::Resource
 
   has_many :organizations do
     data do
+      # Staff yields membership to all active organizations.
       @object.staff? ? Organization.is_active : @object.organizations
+    end
+  end
+
+  has_many :memberships do
+    data do
+      # Only return active membership relations
+      @object.memberships { |membership| membership.active }
     end
   end
 end

--- a/spec/api/users_spec.rb
+++ b/spec/api/users_spec.rb
@@ -9,12 +9,18 @@ RSpec.describe "Accessing a user profile" do
 
       expect(response).to be_successful
 
-      organizations = json_data.fetch(:included, [])
+      # expecting one organization and one membership
+      expect(json_data.fetch(:included, []).size).to eq(2)
+
+      organizations = json_data.fetch(:included, []).select { |included| included.dig(:type) == "organization" }
       expect(organizations.size).to eq(user.organizations.size)
       user.organizations.each do |organization|
         serialized_organization = organizations.find { |other_organization| other_organization[:id].to_i == organization.id }
         expect(serialized_organization.dig(:attributes, :name)).to eq(organization.name)
       end
+
+      memberships = json_data.fetch(:included, []).select { |included| included.dig(:type) == "membership" }
+      expect(memberships.size).to eq(user.memberships.size)
     end
   end
 


### PR DESCRIPTION
This PR adds organisation membership information as relationship and included record to the API `/profile` endpoint's response: 

```json
{
  "data": {
    "id": "7",
    "type": "user",
    "attributes": {
      "first_name": "Misti",
      "last_name": "Metz"
    },
    "relationships": {
      "organizations": {
        "data": [
          {
            "type": "organization",
            "id": "1"
          }
        ]
      },
      "memberships": {
        "data": [
          {
            "type": "membership",
            "id": "5"
          }
        ]
      }
    }
  },
  "included": [
    {
      "id": "1",
      "type": "organization",
      "attributes": {
        "name": "Acme Museum"
      }
    },
    {
      "id": "5",
      "type": "membership",
      "attributes": {
        "active": true,
        "first_name": "Misti",
        "last_name": "Metz",
        "email": "admin@example.com",
        "role": "admin",
        "organization_id": "1"
      }
    }
  ],
  "jsonapi": {
    "version": "1.0"
  }
}
```