### PR TITLE
Replace ENV.fetch() by ENV[] to get DATABASE_URL config variable

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
 development:
   <<: *default
   database: coyote_development
-  url: <%= ENV.fetch('DATABASE_URL') %>
+  url: <%= ENV["DATABASE_URL"] %>
 
 test: &test
   <<: *default


### PR DESCRIPTION
The database configuration used `ENV.fetch()` to get the `DATABASE_URL` environment variable, this throws a `KeyError` when the ENV key does not exist. In production this variable is not used, hence attempting to bring up the server would throw a `KeyError`. This PR uses the `ENV["DATABASE_URL"]` syntax instead, which silently defaults to `Nil`.