### PR TITLE
Hotfix for appsignal configuration parsing

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,5 +1,5 @@
 default: &defaults
-  push_api_key: "<%= Credentials.fetch(:appsignal, :push_api_key) %>"
+  push_api_key: "<%= Credentials.fetch(:appsignal, :push_api_key) { "" } %>"
 
   # Your app's name
   name: "Coyote"


### PR DESCRIPTION
Appsignal only runs in staging/production mode, hence this wasn't caught in development or test (and is a symptom that should be addressed).