### PR TITLE
Remove Appsignal front-end initialisation

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -84,11 +84,3 @@ html(lang="en")
     = javascript_pack_tag "application"
     = yield :javascript_footer
     javascript:
-      (() => {
-          const appsignalKey = #{Credentials.dig(:appsignal, :frontend_push_api_key).to_json};
-          if (Appsignal instanceof Function && appsignalKey !== null) {
-              window.appsignal = new Appsignal({
-                  key: appsignalKey
-              })
-          }
-      })();


### PR DESCRIPTION
We're not tracking any errors yet, so to have it initialising in the footer is not necessary.