### PR TITLE
Add partial organizations index on unique name when not deleted.

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -16,7 +16,7 @@
 # Indexes
 #
 #  index_organizations_on_is_deleted  (is_deleted)
-#  index_organizations_on_name        (name) UNIQUE
+#  index_organizations_on_name        (name) UNIQUE WHERE (is_deleted IS FALSE)
 #
 # Foreign Keys
 #

--- a/db/migrate/20220725061155_alter_organizations_unique_name_index.rb
+++ b/db/migrate/20220725061155_alter_organizations_unique_name_index.rb
@@ -1,0 +1,6 @@
+class AlterOrganizationsUniqueNameIndex < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :organizations, :name
+    add_index :organizations, :name, unique: true, where: "is_deleted IS FALSE"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_21_221224) do
+ActiveRecord::Schema.define(version: 2022_07_25_061155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -190,7 +190,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_221224) do
     t.string "footer"
     t.boolean "allow_authors_to_claim_resources", default: false, null: false
     t.index ["is_deleted"], name: "index_organizations_on_is_deleted"
-    t.index ["name"], name: "index_organizations_on_name", unique: true
+    t.index ["name"], name: "index_organizations_on_name", unique: true, where: "(is_deleted IS FALSE)"
   end
 
   create_table "password_resets", force: :cascade do |t|

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -16,7 +16,7 @@
 # Indexes
 #
 #  index_organizations_on_is_deleted  (is_deleted)
-#  index_organizations_on_name        (name) UNIQUE
+#  index_organizations_on_name        (name) UNIQUE WHERE (is_deleted IS FALSE)
 #
 # Foreign Keys
 #

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -16,7 +16,7 @@
 # Indexes
 #
 #  index_organizations_on_is_deleted  (is_deleted)
-#  index_organizations_on_name        (name) UNIQUE
+#  index_organizations_on_name        (name) UNIQUE WHERE (is_deleted IS FALSE)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
Organizations were previously indexed on their unique name; this caused an index constraint error when "Acme Museum" was deleted and then recreated. This partial index resolves this such that multiple deleted organizations with the same name can exist, but only a single "Acme Museum" that is not deleted can only ever exist.

This addresses #593.