### PR TITLE
Do not constrain resource source_uri when identical uri resource is soft-deleted

### DIFF
--- a/app/assets/stylesheets/elements/_resources.sass
+++ b/app/assets/stylesheets/elements/_resources.sass
@@ -85,3 +85,13 @@
 +in-card-table
   .resource-status
     display: none
+
+h1 .soft-deleted
+  color: white
+  background-color: crimson
+  font-size: initial
+  font-weight: initial
+  margin-left: 0.5em
+  padding: 0.5em 1.2em
+  border-radius: 2em 0.5em
+  vertical-align: top

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -78,6 +78,9 @@ class ResourcesController < ApplicationController
 
   def authorize_unit_access
     authorize(resource)
+    if resource.soft_deleted? && !current_user.staff?
+      raise ActiveRecord::RecordNotFound
+    end
   end
 
   def check_for_canonical_id

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -100,9 +100,11 @@ class ResourcesController < ApplicationController
   end
 
   def record_filter
-    @record_filter ||= RecordFilter.new(filter_params, pagination_params, current_organization.resources,
-                                        default_filters: {is_deleted_eq: false},
-                                        default_order: ['by_name'])
+    @record_filter ||= RecordFilter.new(
+      filter_params, pagination_params, current_organization.resources,
+      default_filters: {is_deleted_eq: false},
+      default_order:   ["by_name"]
+    )
   end
 
   def resource_groups

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -73,34 +73,14 @@ module FilterHelper
     content = capture(&block)
 
     # Take all permitted pre-existing parameters but strip the "sort" parameter as it's redefined by the select dropdown
-    permitted_params = params.fetch(:q, {}).permit(*RESOURCE_FILTERS.reject{ |n| n == :s })
+    permitted_params = params.fetch(:q, {}).permit(*RESOURCE_FILTERS.reject { |n| n == :s })
 
     # Include all pre-existing parameters as hidden fields
-    hidden_fields = permitted_params.to_h.map do
-      |key, value| tag.input(value:value, type:'hidden', name: "q[#{key}]")
+    hidden_fields = permitted_params.to_h.map do |key, value|
+      tag.input(value: value, type: "hidden", name: "q[#{key}]")
     end.flatten
 
     tag.form(safe_join([content, hidden_fields]), options)
-  end
-
-  def sort_select(options = {}, &block)
-    content = capture(&block)
-    tag.div(safe_join([
-      tag.label("Sort order", for: "resource_sort_options", class: 'form-field-label'),
-      # q[s] is the Ransack sorting parameter
-      tag.select(content, id: "resource_sort_options", name: "q[s]")
-    ]), class: 'form-field')
-  end
-
-  def sort_option(attribute, direction, label)
-    sort = "#{attribute} #{direction}"
-    active_sort = params.dig(:q, :s)
-
-    options = {value: sort}.tap do |o|
-      o[:selected] = 1 if active_sort == sort
-    end
-
-    tag.option(label, options)
   end
 
   def sort_link_to(attribute, *args)
@@ -120,5 +100,25 @@ module FilterHelper
       # Determine if the requested sort is the one already applied
       @_active_sort_label = label if active_sort.present? && active_sort == sort
     end
+  end
+
+  def sort_option(attribute, direction, label)
+    sort = "#{attribute} #{direction}"
+    active_sort = params.dig(:q, :s)
+
+    options = {value: sort}.tap do |o|
+      o[:selected] = 1 if active_sort == sort
+    end
+
+    tag.option(label, options)
+  end
+
+  def sort_select(options = {}, &block)
+    content = capture(&block)
+    tag.div(safe_join([
+      tag.label("Sort order", for: "resource_sort_options", class: "form-field-label"),
+      # q[s] is the Ransack sorting parameter
+      tag.select(content, id: "resource_sort_options", name: "q[s]"),
+    ]), class: "form-field")
   end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -29,7 +29,7 @@
 #  index_resources_on_representations_count             (representations_count)
 #  index_resources_on_schemaless_source_uri             (source_uri) USING gin
 #  index_resources_on_source_uri                        (source_uri)
-#  index_resources_on_source_uri_and_organization_id    (source_uri,organization_id) UNIQUE WHERE ((source_uri IS NOT NULL) AND (source_uri <> ''::citext))
+#  index_resources_on_source_uri_and_organization_id    (source_uri,organization_id) UNIQUE WHERE ((source_uri IS NOT NULL) AND (source_uri <> ''::citext) AND (is_deleted IS FALSE))
 #
 # Foreign Keys
 #

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -302,6 +302,10 @@ class Resource < ApplicationRecord
     @new_resource_group_ids = organization.resource_groups.where(id: new_ids).pluck(:id) # ensure we only attach resource groups for this org
   end
 
+  def soft_deleted?
+    is_deleted
+  end
+
   def unassigned?
     return @unassigned if defined? @unassigned
     @unassigned = active_assignments.none?

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -1,4 +1,7 @@
-h1= title(resource.name)
+h1
+  =title(resource.name)
+  - if resource.soft_deleted?
+    span.soft-deleted Soft deleted
 
 .split-view.split-view--thumbnail
   .split-view-item

--- a/db/migrate/20221215104530_alter_resources_unique_source_uri_index.rb
+++ b/db/migrate/20221215104530_alter_resources_unique_source_uri_index.rb
@@ -1,0 +1,6 @@
+class AlterResourcesUniqueSourceURIIndex < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :resources, [:source_uri, :organization_id]
+    add_index :resources, [:source_uri, :organization_id], unique: true, where: "source_uri IS NOT NULL AND source_uri <> ''::citext AND is_deleted IS FALSE"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_25_061155) do
+ActiveRecord::Schema.define(version: 2022_12_15_104530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -309,7 +309,7 @@ ActiveRecord::Schema.define(version: 2022_07_25_061155) do
     t.index ["organization_id"], name: "index_resources_on_organization_id"
     t.index ["priority_flag"], name: "index_resources_on_priority_flag", order: :desc
     t.index ["representations_count"], name: "index_resources_on_representations_count"
-    t.index ["source_uri", "organization_id"], name: "index_resources_on_source_uri_and_organization_id", unique: true, where: "((source_uri IS NOT NULL) AND (source_uri <> ''::citext))"
+    t.index ["source_uri", "organization_id"], name: "index_resources_on_source_uri_and_organization_id", unique: true, where: "((source_uri IS NOT NULL) AND (source_uri <> ''::citext) AND (is_deleted IS FALSE))"
     t.index ["source_uri"], name: "index_resources_on_schemaless_source_uri", opclass: :gin_trgm_ops, using: :gin
     t.index ["source_uri"], name: "index_resources_on_source_uri"
   end

--- a/lib/coyote/helpers/production_config_helper.rb
+++ b/lib/coyote/helpers/production_config_helper.rb
@@ -32,7 +32,7 @@ module Coyote
           write_timeout:      0.2, # Defaults to 1 second
           reconnect_attempts: 0, # Defaults to 0
           pool_size:          5,
-          pool_timeout:       5
+          pool_timeout:       5,
         }
       end
     end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -29,7 +29,7 @@
 #  index_resources_on_representations_count             (representations_count)
 #  index_resources_on_schemaless_source_uri             (source_uri) USING gin
 #  index_resources_on_source_uri                        (source_uri)
-#  index_resources_on_source_uri_and_organization_id    (source_uri,organization_id) UNIQUE WHERE ((source_uri IS NOT NULL) AND (source_uri <> ''::citext))
+#  index_resources_on_source_uri_and_organization_id    (source_uri,organization_id) UNIQUE WHERE ((source_uri IS NOT NULL) AND (source_uri <> ''::citext) AND (is_deleted IS FALSE))
 #
 # Foreign Keys
 #

--- a/spec/lib/coyote/helpers/production_config_helper_spec.rb
+++ b/spec/lib/coyote/helpers/production_config_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Coyote::Helpers::ProductionConfigHelper do
     it("sets the namespace to \"`Rails.env`\" if ENV[\"STAGING\"] is not present") do
       ENV.delete("STAGING")
       config = subject.redis_cache_config
-      expect(config[:namespace]).to eq("coyote-cache-development")
+      expect(config[:namespace]).to eq("coyote-cache-test")
     end
   end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -29,7 +29,7 @@
 #  index_resources_on_representations_count             (representations_count)
 #  index_resources_on_schemaless_source_uri             (source_uri) USING gin
 #  index_resources_on_source_uri                        (source_uri)
-#  index_resources_on_source_uri_and_organization_id    (source_uri,organization_id) UNIQUE WHERE ((source_uri IS NOT NULL) AND (source_uri <> ''::citext))
+#  index_resources_on_source_uri_and_organization_id    (source_uri,organization_id) UNIQUE WHERE ((source_uri IS NOT NULL) AND (source_uri <> ''::citext) AND (is_deleted IS FALSE))
 #
 # Foreign Keys
 #


### PR DESCRIPTION
This closes #664 by allowing duplicate `organization_id` and `source_uri` columns with differing `is_deleted` values.