### PR TITLE
Faraday handles HTTP redirect responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "audited"
 gem "bcrypt", "~> 3.1.7"
 gem "bootsnap", require: false
 gem "faraday"
+gem "faraday_middleware"
 gem "ffi", require: false
 gem "htmlentities"
 gem "jsonapi-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
+    faraday_middleware (1.2.0)
+      faraday (~> 1.0)
     federal_offense (0.1.2)
       rails (~> 6.0, >= 6.0.3.1)
     ffi (1.15.0)
@@ -449,6 +451,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday
+  faraday_middleware
   federal_offense (>= 0.1.2)
   ffi
   guard

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -100,9 +100,11 @@ class ResourcesController < ApplicationController
   end
 
   def record_filter
-    @record_filter ||= RecordFilter.new(filter_params, pagination_params, current_organization.resources,
-                                        default_filters: {is_deleted_eq: false},
-                                        default_order: ['by_name'])
+    @record_filter ||= RecordFilter.new(
+      filter_params, pagination_params, current_organization.resources,
+      default_filters: {is_deleted_eq: false},
+      default_order:   ["by_name"]
+    )
   end
 
   def resource_groups

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -73,34 +73,14 @@ module FilterHelper
     content = capture(&block)
 
     # Take all permitted pre-existing parameters but strip the "sort" parameter as it's redefined by the select dropdown
-    permitted_params = params.fetch(:q, {}).permit(*RESOURCE_FILTERS.reject{ |n| n == :s })
+    permitted_params = params.fetch(:q, {}).permit(*RESOURCE_FILTERS.reject { |n| n == :s })
 
     # Include all pre-existing parameters as hidden fields
-    hidden_fields = permitted_params.to_h.map do
-      |key, value| tag.input(value:value, type:'hidden', name: "q[#{key}]")
+    hidden_fields = permitted_params.to_h.map do |key, value|
+      tag.input(value: value, type: "hidden", name: "q[#{key}]")
     end.flatten
 
     tag.form(safe_join([content, hidden_fields]), options)
-  end
-
-  def sort_select(options = {}, &block)
-    content = capture(&block)
-    tag.div(safe_join([
-      tag.label("Sort order", for: "resource_sort_options", class: 'form-field-label'),
-      # q[s] is the Ransack sorting parameter
-      tag.select(content, id: "resource_sort_options", name: "q[s]")
-    ]), class: 'form-field')
-  end
-
-  def sort_option(attribute, direction, label)
-    sort = "#{attribute} #{direction}"
-    active_sort = params.dig(:q, :s)
-
-    options = {value: sort}.tap do |o|
-      o[:selected] = 1 if active_sort == sort
-    end
-
-    tag.option(label, options)
   end
 
   def sort_link_to(attribute, *args)
@@ -120,5 +100,25 @@ module FilterHelper
       # Determine if the requested sort is the one already applied
       @_active_sort_label = label if active_sort.present? && active_sort == sort
     end
+  end
+
+  def sort_option(attribute, direction, label)
+    sort = "#{attribute} #{direction}"
+    active_sort = params.dig(:q, :s)
+
+    options = {value: sort}.tap do |o|
+      o[:selected] = 1 if active_sort == sort
+    end
+
+    tag.option(label, options)
+  end
+
+  def sort_select(options = {}, &block)
+    content = capture(&block)
+    tag.div(safe_join([
+      tag.label("Sort order", for: "resource_sort_options", class: "form-field-label"),
+      # q[s] is the Ransack sorting parameter
+      tag.select(content, id: "resource_sort_options", name: "q[s]"),
+    ]), class: "form-field")
   end
 end

--- a/lib/coyote/helpers/production_config_helper.rb
+++ b/lib/coyote/helpers/production_config_helper.rb
@@ -32,7 +32,7 @@ module Coyote
           write_timeout:      0.2, # Defaults to 1 second
           reconnect_attempts: 0, # Defaults to 0
           pool_size:          5,
-          pool_timeout:       5
+          pool_timeout:       5,
         }
       end
     end

--- a/spec/lib/coyote/helpers/production_config_helper_spec.rb
+++ b/spec/lib/coyote/helpers/production_config_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Coyote::Helpers::ProductionConfigHelper do
     it("sets the namespace to \"`Rails.env`\" if ENV[\"STAGING\"] is not present") do
       ENV.delete("STAGING")
       config = subject.redis_cache_config
-      expect(config[:namespace]).to eq("coyote-cache-development")
+      expect(config[:namespace]).to eq("coyote-cache-test")
     end
   end
 end

--- a/spec/support/webhook_context.rb
+++ b/spec/support/webhook_context.rb
@@ -17,6 +17,35 @@ RSpec.shared_context "with webhooks" do
   }
 end
 
+def create_redirection_context(code)
+  RSpec.shared_context "with #{code} redirected webhooks" do
+    let(:resource_group) { create(:resource_group, webhook_uri: "http://www.example.com/webhook/goes/here") }
+    let(:redirect_location) { "http://www.example.com/webhook/redirected/url" }
+
+    around do |example|
+      VCR.use_cassette("#{code}_redirected_webhooks", record: :new_episodes) do
+        example.run
+      end
+    end
+
+    let!(:request) {
+      stub_request(:post, resource_group.webhook_uri).to_return(
+        status:  code,
+        headers: {
+          'Location': redirect_location,
+        },
+      )
+
+      stub_request(:post, redirect_location).to_return(
+        body:   "REDIRECTION_FOLLOWED",
+        status: 200,
+      )
+    }
+  end
+end
+
+[301, 302, 303, 307, 308].each { |code| create_redirection_context(code) }
+
 RSpec.shared_context "without webhooks" do
   around do |example|
     Sidekiq::Testing.fake! do


### PR DESCRIPTION
This closes #657. 

Webhook redirects for HTTP 301, 302 and 303 should not be followed as the `Location` header target should only respond to a GET. This raises a custom exception for debugging and logging purposes.

HTTP 307 should be handled properly (by issuing the same request to its `Location` target.

