### PR TITLE
Include host uris in serialised resource

### DIFF
--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -100,9 +100,11 @@ class ResourcesController < ApplicationController
   end
 
   def record_filter
-    @record_filter ||= RecordFilter.new(filter_params, pagination_params, current_organization.resources,
-                                        default_filters: {is_deleted_eq: false},
-                                        default_order: ['by_name'])
+    @record_filter ||= RecordFilter.new(
+      filter_params, pagination_params, current_organization.resources,
+      default_filters: {is_deleted_eq: false},
+      default_order:   ["by_name"]
+    )
   end
 
   def resource_groups

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -73,34 +73,14 @@ module FilterHelper
     content = capture(&block)
 
     # Take all permitted pre-existing parameters but strip the "sort" parameter as it's redefined by the select dropdown
-    permitted_params = params.fetch(:q, {}).permit(*RESOURCE_FILTERS.reject{ |n| n == :s })
+    permitted_params = params.fetch(:q, {}).permit(*RESOURCE_FILTERS.reject { |n| n == :s })
 
     # Include all pre-existing parameters as hidden fields
-    hidden_fields = permitted_params.to_h.map do
-      |key, value| tag.input(value:value, type:'hidden', name: "q[#{key}]")
+    hidden_fields = permitted_params.to_h.map do |key, value|
+      tag.input(value: value, type: "hidden", name: "q[#{key}]")
     end.flatten
 
     tag.form(safe_join([content, hidden_fields]), options)
-  end
-
-  def sort_select(options = {}, &block)
-    content = capture(&block)
-    tag.div(safe_join([
-      tag.label("Sort order", for: "resource_sort_options", class: 'form-field-label'),
-      # q[s] is the Ransack sorting parameter
-      tag.select(content, id: "resource_sort_options", name: "q[s]")
-    ]), class: 'form-field')
-  end
-
-  def sort_option(attribute, direction, label)
-    sort = "#{attribute} #{direction}"
-    active_sort = params.dig(:q, :s)
-
-    options = {value: sort}.tap do |o|
-      o[:selected] = 1 if active_sort == sort
-    end
-
-    tag.option(label, options)
   end
 
   def sort_link_to(attribute, *args)
@@ -120,5 +100,25 @@ module FilterHelper
       # Determine if the requested sort is the one already applied
       @_active_sort_label = label if active_sort.present? && active_sort == sort
     end
+  end
+
+  def sort_option(attribute, direction, label)
+    sort = "#{attribute} #{direction}"
+    active_sort = params.dig(:q, :s)
+
+    options = {value: sort}.tap do |o|
+      o[:selected] = 1 if active_sort == sort
+    end
+
+    tag.option(label, options)
+  end
+
+  def sort_select(options = {}, &block)
+    content = capture(&block)
+    tag.div(safe_join([
+      tag.label("Sort order", for: "resource_sort_options", class: "form-field-label"),
+      # q[s] is the Ransack sorting parameter
+      tag.select(content, id: "resource_sort_options", name: "q[s]"),
+    ]), class: "form-field")
   end
 end

--- a/app/serializers/serializable_resource.rb
+++ b/app/serializers/serializable_resource.rb
@@ -4,7 +4,7 @@
 class SerializableResource < ApplicationSerializer
   type "resource"
 
-  attributes :id, :name, :resource_type, :canonical_id, :source_uri, :created_at, :updated_at
+  attributes :id, :name, :resource_type, :host_uris, :canonical_id, :source_uri, :created_at, :updated_at
 
   attribute :resource_group do
     @object.resource_group_name

--- a/lib/coyote/helpers/production_config_helper.rb
+++ b/lib/coyote/helpers/production_config_helper.rb
@@ -32,7 +32,7 @@ module Coyote
           write_timeout:      0.2, # Defaults to 1 second
           reconnect_attempts: 0, # Defaults to 0
           pool_size:          5,
-          pool_timeout:       5
+          pool_timeout:       5,
         }
       end
     end

--- a/spec/lib/coyote/helpers/production_config_helper_spec.rb
+++ b/spec/lib/coyote/helpers/production_config_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Coyote::Helpers::ProductionConfigHelper do
     it("sets the namespace to \"`Rails.env`\" if ENV[\"STAGING\"] is not present") do
       ENV.delete("STAGING")
       config = subject.redis_cache_config
-      expect(config[:namespace]).to eq("coyote-cache-development")
+      expect(config[:namespace]).to eq("coyote-cache-test")
     end
   end
 end

--- a/spec/serializers/serializable_resource_spec.rb
+++ b/spec/serializers/serializable_resource_spec.rb
@@ -24,4 +24,5 @@ RSpec.describe SerializableResource do
 
   it { is_expected.to include(id: object.id) }
   it { is_expected.to include(canonical_id: object.canonical_id) }
+  it { is_expected.to include(host_uris: object.host_uris) }
 end


### PR DESCRIPTION
This closes #670 by including the resource's `host_uris` property within its `attributes` list.