### PR TITLE
Add DB volume to production compose file

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -8,7 +8,8 @@ services:
       POSTGRES_PASSWORD: postgres
     expose:
       - 5432
-    volumes: []
+    volumes:
+      - db:/var/lib/postgresql/data
 
   redis:
     image: redis:7.0.0-alpine3.16
@@ -56,3 +57,6 @@ services:
       - redis
     ports: []
 
+volumes:
+  db:
+  


### PR DESCRIPTION
This work modifies `docker-compose-production.yml` to add a volume to the Postgres container so the database persists between taking containers down and spinning them back up. This Allows Coyote to be reliably taken down and spun up using `docker-compose -f docker-compose-production.yml down/upp`