### PR TITLE
Adds one additional Dockerfile run command to support Apple M1 Chips:…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG bundle_without="development test"
 
 RUN apk update \
   && apk upgrade \
+  && apk add --no-cache gcompat \
   && apk add --update --no-cache --virtual .gyp python2 make g++ \
   build-base \
   git \


### PR DESCRIPTION
… '&& apk add --no-cache gcompat \'

Proposed fix for issue #694

Change adds the gcompat library when running the initial Dockerfile setup. Gcompat is a library which provides glibc-compatible APIs for use on musl libc systems. The library is designed to be used for binaries that are already compiled against glibc.

[Here](https://git.adelielinux.org/adelie/gcompat) is the link to the library information.
