### PR TITLE
661 creating two resources with identical uris triggers http 500

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ARG bundle_without="development test"
 
 RUN apk update \
   && apk upgrade \
-  && apk add --no-cache gcompat \
   && apk add --update --no-cache --virtual .gyp python2 make g++ \
   build-base \
   git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG bundle_without="development test"
 
 RUN apk update \
   && apk upgrade \
+  && apk add --no-cache gcompat \
   && apk add --update --no-cache --virtual .gyp python2 make g++ \
   build-base \
   git \

--- a/app/controllers/concerns/form_errors.rb
+++ b/app/controllers/concerns/form_errors.rb
@@ -1,3 +1,8 @@
+# frozen_string_literal: true
+
+# Used to rescue form errors that would otherwise raise an exception and display the standard rails 500 error page
+# Needed to rescue from resources controller create action for identical/invalid source URIs and Canonical IDs
+# Can add additional rescue_from statements as needed for other controllers/forms
 module FormErrors
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/form_errors.rb
+++ b/app/controllers/concerns/form_errors.rb
@@ -1,0 +1,32 @@
+module FormErrors
+  extend ActiveSupport::Concern
+
+  included do
+  rescue_from ActiveRecord::RecordNotUnique, with: :not_unique_response
+  rescue_from URI::InvalidURIError, with: :invalid_uri_response
+  end
+
+  private 
+
+  def not_unique_response(e)
+    response = check_unique_error(e)
+    resource.errors.add(:base, response)
+    logger.warn "Unable to create resource due to '#{e.message}'"
+    render :new, status: :unprocessable_entity
+  end
+
+  def check_unique_error(e)
+    if e.message.include?("canonical_id")
+      "The Canonical ID is already in use for this organization."
+    elsif e.message.include?("source_uri")
+      "The Source URI is already in use for this organization."
+    end
+  end
+
+  def invalid_uri_response(e)
+    response = "The Source URI is invalid."
+    resource.errors.add(:base, response)
+    logger.warn "Unable to create resource due to '#{e.message}'"
+    render :new, status: :unprocessable_entity
+  end
+end

--- a/app/controllers/concerns/permitted_parameters.rb
+++ b/app/controllers/concerns/permitted_parameters.rb
@@ -62,10 +62,11 @@ module PermittedParameters
       union_host_uris
       union_resource_groups
       uploaded_resource
+      organization_id
     ] + [{
       host_uris:          [],
       representations:    REPRESENTATION_PARAMS,
-      resource_group_ids: [],
+      resource_group_ids: []
     }]).freeze
 
   private
@@ -76,8 +77,9 @@ module PermittedParameters
     end
   end
 
-  def clean_resource_params(resource_params)
+  def clean_resource_params(resource_params, org_id)
     resource_params = ActionController::Parameters.new(resource_params) unless resource_params.respond_to?(:permit)
+    resource_params[:organization_id] = org_id
     resource_params.permit(*RESOURCE_PARAMS).tap do |params|
       representations = params.delete(:representations)
       if representations.present?
@@ -101,7 +103,7 @@ module PermittedParameters
     clean_representation_params(params.require(:representation))
   end
 
-  def resource_params
-    clean_resource_params(params.require(:resource))
+  def resource_params(org_id)
+    clean_resource_params(params.require(:resource), org_id)
   end
 end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -5,6 +5,7 @@
 # @see ResourcePolicy
 class ResourcesController < ApplicationController
   include PermittedParameters
+  include FormErrors
 
   before_action :check_for_canonical_id, only: %i[show]
   before_action :set_resource, only: %i[show edit update destroy]

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -15,15 +15,11 @@ class ResourcesController < ApplicationController
   helper_method :resource, :record_filter, :filter_params, :resource_groups
 
   def create
-    self.resource = current_organization.resources.new
+    self.resource = current_organization.resources.new(resource_params(current_organization.id))
 
-    if resource.update(resource_params)
-      logger.info "Created #{resource}"
-      redirect_to resource, notice: "The resource has been created"
-    else
-      logger.warn "Unable to create resource due to '#{resource.error_sentence}'"
-      render :new
-    end
+    resource.save
+    logger.info "Created #{resource}"
+    redirect_to resource, notice: "The resource has been created"
   end
 
   def destroy

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -16,10 +16,14 @@ class ResourcesController < ApplicationController
 
   def create
     self.resource = current_organization.resources.new(resource_params(current_organization.id))
-
-    resource.save
-    logger.info "Created #{resource}"
-    redirect_to resource, notice: "The resource has been created"
+    
+    if resource.save
+      logger.info "Created #{resource}"
+      redirect_to resource, notice: "The resource has been created"
+    else
+      logger.warn "Unable to create resource due to '#{resource.error_sentence}'"
+      render :new
+    end
   end
 
   def destroy

--- a/app/views/resources/_form.html.slim
+++ b/app/views/resources/_form.html.slim
@@ -1,5 +1,7 @@
 = simple_form_for target, validate: true, html: { multipart: true } do |f|
-  = f.error_notification
+  - if f.object.errors.any?
+    - f.object.errors.full_messages.each do |message|
+      .error_notification= message
 
   = f.input :name, label: 'Caption'
   = f.input :source_uri, label: 'Source URI', hint: 'Identifies the canonical location of the resource', required: true

--- a/spec/features/resource_adding_and_changing_spec.rb
+++ b/spec/features/resource_adding_and_changing_spec.rb
@@ -41,8 +41,9 @@ RSpec.describe "Resource adding and changing" do
   end
 
   context "when invalid resource attributes are submitted" do
-    let!(:resource) { create(:resource, organization_id: user_organization.id) }
+    let!(:resource) { create(:resource, organization_id: user_organization.id, canonical_id: '4') }
     let(:resource_uri) { resource.source_uri }
+    let(:resource_canonical_id) { resource.canonical_id }
 
     describe 'source URI is invalid' do
       it "should display an error message and re-render the form" do
@@ -67,6 +68,19 @@ RSpec.describe "Resource adding and changing" do
     
         expect(page).to have_current_path(resources_path(organization_id: user_organization))
         expect(page).to have_content("The Source URI is already in use for this organization.")
+      end
+    end
+
+    describe 'canonical uri is not unique' do
+      it "should display an error message and re-render the form" do
+        fill_in "Caption", with: resource_attributes[:name]
+        fill_in "Canonical ID", with: resource_canonical_id
+        fill_in "Source URI", with: resource_attributes[:source_uri]
+        fill_in "Host URIs", with: "http://example.com/abc\nhttp://example.com/xyz"
+        click_button("Create Resource")
+    
+        expect(page).to have_current_path(resources_path(organization_id: user_organization))
+        expect(page).to have_content("The Canonical ID is already in use for this organization.")
       end
     end
   end

--- a/spec/features/resource_adding_and_changing_spec.rb
+++ b/spec/features/resource_adding_and_changing_spec.rb
@@ -37,4 +37,44 @@ RSpec.describe "Resource adding and changing" do
     expect(page).to have_current_path(resource_path(resource, organization_id: user_organization), ignore_query: true)
     expect(page).to have_content(resource.name)
   end
+
+  context "when invalid resource attributes are submitted" do
+    describe 'source URI is invalid' do
+      let!(:resource) { create(:resource, organization_id: user_organization.id) }
+      let(:resource_uri) { resource.source_uri }
+
+      it "should display an error message and re-render the form" do
+        click_first_link "Resources"
+        click_first_link("Add Resource")
+
+        fill_in "Caption", with: resource_attributes[:name]
+        fill_in "Canonical ID", with: resource_attributes[:canonical_id]
+        fill_in "Source URI", with: "Hello World!"
+        fill_in "Host URIs", with: "http://example.com/abc\nhttp://example.com/xyz"
+        click_button("Create Resource")
+
+        expect(page).to have_current_path(resources_path(organization_id: user_organization))
+        expect(page).to have_content("The Source URI is invalid.")
+      end
+    end
+
+    describe 'source uri is not unique' do
+      let!(:resource) { create(:resource, organization_id: user_organization.id) }
+      let(:resource_uri) { resource.source_uri }
+
+      it "should display an error message and re-render the form" do
+        click_first_link "Resources"
+        click_first_link("Add Resource")
+
+        fill_in "Caption", with: resource_attributes[:name]
+        fill_in "Canonical ID", with: resource_attributes[:canonical_id]
+        fill_in "Source URI", with: resource_uri
+        fill_in "Host URIs", with: "http://example.com/abc\nhttp://example.com/xyz"
+        click_button("Create Resource")
+    
+        expect(page).to have_current_path(resources_path(organization_id: user_organization))
+        expect(page).to have_content("The Source URI is already in use for this organization.")
+      end
+    end
+  end
 end

--- a/spec/features/resource_adding_and_changing_spec.rb
+++ b/spec/features/resource_adding_and_changing_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe "Resource adding and changing" do
     attributes_for(:resource, canonical_id: "abc123").symbolize_keys
   end
 
-  it "succeeds" do
+  before(:each) do
     click_first_link "Resources"
     click_first_link("Add Resource")
+  end
 
+  it "succeeds" do
     within(".form-field.resource_resource_groups") do
       user_organization.resource_groups.default.each do |other_group|
         uncheck(other_group.name)
@@ -39,14 +41,11 @@ RSpec.describe "Resource adding and changing" do
   end
 
   context "when invalid resource attributes are submitted" do
+    let!(:resource) { create(:resource, organization_id: user_organization.id) }
+    let(:resource_uri) { resource.source_uri }
+
     describe 'source URI is invalid' do
-      let!(:resource) { create(:resource, organization_id: user_organization.id) }
-      let(:resource_uri) { resource.source_uri }
-
       it "should display an error message and re-render the form" do
-        click_first_link "Resources"
-        click_first_link("Add Resource")
-
         fill_in "Caption", with: resource_attributes[:name]
         fill_in "Canonical ID", with: resource_attributes[:canonical_id]
         fill_in "Source URI", with: "Hello World!"
@@ -59,13 +58,7 @@ RSpec.describe "Resource adding and changing" do
     end
 
     describe 'source uri is not unique' do
-      let!(:resource) { create(:resource, organization_id: user_organization.id) }
-      let(:resource_uri) { resource.source_uri }
-
       it "should display an error message and re-render the form" do
-        click_first_link "Resources"
-        click_first_link("Add Resource")
-
         fill_in "Caption", with: resource_attributes[:name]
         fill_in "Canonical ID", with: resource_attributes[:canonical_id]
         fill_in "Source URI", with: resource_uri


### PR DESCRIPTION
- Fix for ActiveRecord::RecordNotUnique (PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_resources_on_organization_id_and_canonical_id" when creating a resource with an already in use Canonical ID or Source URI.

- Creates a FormError module to rescue from PG errors and display errors gracefully, instead of displaying the default Rails 500 internal server error page.

- Modifies the create method in the ResourcesController to be compatible with the FormError Module.

- Modifies the _form partial to use the form object to display errors.

<figure>
<figcaption>Screenshot of the error page before the fix<f/figcaption>
<img width="1397" alt="Screenshot of the default Rails 500 Internal Server Error Page. Displays the following message at the top: ActiveRecord::RecordNotUnique in ResourcesController#create. Then displays the message: PG::UniqueViolation: ERROR: duplicate key value violates unique constraint 'index_resources_on_organization_id_and_canonical_id' DETAIL: Key (organization_id, canonical_id)=(1, 4) already exists. beneath the initial message." src="https://github.com/coyote-team/coyote/assets/86209646/533a2b2b-2aa5-4674-87ec-a897ad738306">
<figure>


<figure>
<figcaption>Screenshot of the form with error message after fix</figcaption>
<img width="822" alt="Screenshot of the create a new resource form with an error message at the top that reads: The Canonical ID is already in use for this organization. The error message is displayed below the Add a Resource header and above the first form field. The error message is in a red box with white font." src="https://github.com/coyote-team/coyote/assets/86209646/77363a5e-3da7-48ef-8191-0fed4a17dd41">
</figure>