### PR TITLE
Description filter component does not correctly apply chosen filters fix

### DIFF
--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -17,7 +17,7 @@ module FilterHelper
       # Explicit ActiveRecord scopes!
       value.to_s.humanize
     else
-      filter.to_s.humanize
+      "#{filter.to_s.humanize}: #{value.to_s.humanize}"
     end
 
     namespace = "#{record_filter.i18n_key}.#{filter}"


### PR DESCRIPTION
- Modifies the filter_name_for method so that the remove_filter_link HTML tag includes the filter name and value instead of just the filter name.

Before example:
![Screenshot of the descriptions page before fix. There are chosen filters for status: ready to approve and metum: alt. Once the filters are chosen and the new results are displayed, the active filters icons only display Metum id in and Status in leaving off the values. The filter icons are highlighted by a red rectangle in the screenshot.](https://github.com/coyote-team/coyote/assets/86209646/ffd17d11-7d4a-444d-a461-175d62ea8ccb)

After fix example:
![Screenshot of the descriptions page after fix. There are chosen filters for 'status: ready to approve' and 'metum: alt'. Once the filters are chosen and the new results are displayed, the active filters icons display 'Metum id in: 1' and 'Status in: Ready to approve'. The filter icons are highlighted by a red rectangle in the screenshot.](https://github.com/coyote-team/coyote/assets/86209646/f40437bf-4dda-47e5-b741-c09a3e436de6)