### PR TITLE
650 resource list toolbar renders orphan list item fix

### DIFF
--- a/app/assets/stylesheets/components/_toolbar.sass
+++ b/app/assets/stylesheets/components/_toolbar.sass
@@ -10,6 +10,11 @@
     flex-direction: column
     align-items: flex-start
 
+  .toolbar-list
+    display: flex;
+    align-items: center;
+    width: 100%;
+
   .toolbar-item
     display: flex
     margin-bottom: 0

--- a/app/views/representations/index.html.slim
+++ b/app/views/representations/index.html.slim
@@ -36,16 +36,20 @@ h1= title "Descriptions"
     = f.submit "Clear", type: "reset", class: "button button--outline"
 
 .toolbar
-  button.button.button--round.filter-toggle data-toggle-target="body" data-toggle="filters-toggled" type="button"
-    = icon(:options, prefix: safe_join(["Filter ", sr_only(Representation.model_name.human(count: 2).downcase)]))
+  ul.toolbar-list
+    li.toolbar-item 
+      button.button.button--round.filter-toggle data-toggle-target="body" data-toggle="filters-toggled" type="button"
+        = icon(:options, prefix: safe_join(["Filter ", sr_only(Representation.model_name.human(count: 2).downcase)]))
 
-  = applied_filters
+    li.toolbar-item
+      = applied_filters
 
-  = sort_dropdown do
-    = dropdown_option sort_link_to(:name, :asc, "Name, A-Z")
-    = dropdown_option sort_link_to(:name, :desc, "Name, Z-A")
-    = dropdown_option sort_link_to(:created_at, :desc, "Date imported, recent")
-    = dropdown_option sort_link_to(:created_at, :asc, "Date imported, oldest")
+    li.toolbar-item
+      = sort_dropdown do
+        = dropdown_option sort_link_to(:name, :asc, "Name, A-Z")
+        = dropdown_option sort_link_to(:name, :desc, "Name, Z-A")
+        = dropdown_option sort_link_to(:created_at, :desc, "Date imported, recent")
+        = dropdown_option sort_link_to(:created_at, :asc, "Date imported, oldest")
 
 
 = simple_form_for :representation_status_change, url: representation_status_changes_path, html: { class: "filter-view-list", id: "results" } do |form|

--- a/app/views/resources/index.html.slim
+++ b/app/views/resources/index.html.slim
@@ -50,37 +50,42 @@ h1= title "Resources"
     = f.submit "Clear", type: "reset", class: "button button--outline"
 
 .toolbar
-  button.button.button--round.filter-toggle data-toggle-target="body" data-toggle="filters-toggled" type="button"
-    span
-      ' Filter
-      span.sr-only= Resource.model_name.human(count: 2).downcase
-    = icon(:options)
+  ul.toolbar-list
+    li.toolbar-item 
+      button.button.button--round.filter-toggle data-toggle-target="body" data-toggle="filters-toggled" type="button"
+        span
+          ' Filter
+          span.sr-only= Resource.model_name.human(count: 2).downcase
+        = icon(:options)
 
-  = applied_filters
+    li.toolbar-item
+      = applied_filters
 
-  ruby:
-    can_create = policy(Resource).new?
-    can_import = can?(:create, Import)
-  - if can_import || can_create
-    = toolbar_item class: "field" do
-      = link_to("Add Resource", new_resource_path, class: "button") if can_create
-      - if can_import
-        - if can_create
-          // Show the import option as a dropdown beside "Add Resource"
-          = dropdown(label: icon(:chevron_down), toggle: {class: "button button--narrow"}) do
-            = dropdown_option link_to(icon(:cloud_upload, prefix: "Import Resources"), new_import_path)
-        - else
-          // Show the import option as a standalone button
-          = new_link_to("Import Resources", new_import_path)
+    ruby:
+      can_create = policy(Resource).new?
+      can_import = can?(:create, Import)
+    - if can_import || can_create
+      li.toolbar-item.field
+        = toolbar_item class: "field" do
+          = link_to("Add Resource", new_resource_path, class: "button") if can_create
+          - if can_import
+            - if can_create
+              // Show the import option as a dropdown beside "Add Resource"
+              = dropdown(label: icon(:chevron_down), toggle: {class: "button button--narrow"}) do
+                = dropdown_option link_to(icon(:cloud_upload, prefix: "Import Resources"), new_import_path)
+            - else
+              // Show the import option as a standalone button
+              = new_link_to("Import Resources", new_import_path)
 
-  = sort_form(record_filter.search, {id: "sort-resources", enforce_utf8: false}) do
-    h3.sr-only Sort
-    = sort_select do
-      = sort_option(:name, :asc, "Name, A-Z")
-      = sort_option(:name, :desc, "Name, Z-A")
-      = sort_option(:created_at, :desc, "Date imported, recent")
-      = sort_option(:created_at, :asc, "Date imported, oldest")
-    button.button.button--round Sort
+    li.toolbar-item
+      = sort_form(record_filter.search, {id: "sort-resources", enforce_utf8: false}) do
+        h3.sr-only Sort
+        = sort_select do
+          = sort_option(:name, :asc, "Name, A-Z")
+          = sort_option(:name, :desc, "Name, Z-A")
+          = sort_option(:created_at, :desc, "Date imported, recent")
+          = sort_option(:created_at, :asc, "Date imported, oldest")
+        button.button.button--round Sort
 
 = simple_form_for :resource, url: update_many_resources_path, html: { id: "results" } do |form|
   h2.sr-only#results-title


### PR DESCRIPTION
- Fixes orphaned list items in the toolbar for the resources index and representations index pages
- Wraps the toolbar items in an unordered list with a toolbar-list class
- Wraps each element in the toolbar in a list item tag with a class of toolbar-item
- Creates a toolbar list class
- Does not change appearance or functionality