### PR TITLE
Remove transparent color for required field label span

### DIFF
--- a/app/assets/stylesheets/components/_form.sass
+++ b/app/assets/stylesheets/components/_form.sass
@@ -30,7 +30,6 @@
           width: round($input-padding)
 
         .form-field-label-requirement
-          color: transparent
           font-size: $font-size-control
           font-weight: 300
           display: flex


### PR DESCRIPTION
- Changes style for required form field labels.
- Before: The span with content "required" would only appear on hover.
- After: The span is always visible

Before:
![Screenshot of the new Resource form. Required form fields have a red circle next to the form label, but no text indicating they are required](https://github.com/coyote-team/coyote/assets/86209646/cfe42fc3-5c21-48c5-9e7e-a2d4918b5cec)

After:
![Screenshot of the new Resource form. Required form fields have a red circle next to the form label and text opposite the label that reads "(required)". The text is visible even when not hovering or focusing on a form field. The text is highlighted by red rectangles in the screenshot](https://github.com/coyote-team/coyote/assets/86209646/d43d05ed-e4cc-4f94-8298-dde6090a69b8)
